### PR TITLE
Feat: Add token schemas with Pydantic

### DIFF
--- a/login/schemas/user.py
+++ b/login/schemas/user.py
@@ -39,4 +39,10 @@ class UserLogin(BaseModel):
     class Config:
         orm_mode = True
 
+class Token(BaseModel):
+    access_token: str
+    token_type: str
     
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str    


### PR DESCRIPTION
Added 'Token' and 'TokenResponse' schemas to structure token-related responses. These schemas define the access token and its type for authentication handling.